### PR TITLE
Small change to include original edit in the return object

### DIFF
--- a/webapp/src/main/java/crest/siamese/Siamese.java
+++ b/webapp/src/main/java/crest/siamese/Siamese.java
@@ -998,6 +998,7 @@ public class Siamese {
         String hunkFileName = hunk.getFileName();
         int hunkStart = hunk.getStartline();
         int hunkEnd = hunk.getEndline();
+        List<String> hunkEdit = hunk.getEdit();
 
         if (siameseClient == null) { startup(); }
 
@@ -1031,6 +1032,7 @@ public class Siamese {
                             hunkStart,
                             hunkEnd,
                             hunkFileName,
+                            hunkEdit,
                             topDoc.isIdiomatic(),
                             topDoc.getRecommendIdiom()
                     );

--- a/webapp/src/main/java/crest/siamese/githubUtils/GitHubJSONFormatter.java
+++ b/webapp/src/main/java/crest/siamese/githubUtils/GitHubJSONFormatter.java
@@ -41,7 +41,7 @@ public class GitHubJSONFormatter {
         item.put("startline", String.valueOf(r.getStartLine()));
         item.put("endline", String.valueOf(r.getEndLine()));
         item.put("filename", file);
-        item.put("edit", r.getEdit());
+        item.put("edit", r.getEditString());
         item.put("idiomatic", String.valueOf(r.isIdiomatic()));
         item.put("recommend", r.getRecommendIdiom());
 


### PR DESCRIPTION
Earlier in the JSON response, the edit field shows `null`, now fixed to show the original edits from the POST request.